### PR TITLE
use console.clear

### DIFF
--- a/src/Log.js
+++ b/src/Log.js
@@ -8,7 +8,7 @@ class Log extends React.Component {
   }
 
   componentWillUpdate () {
-    window.clear();
+    console.clear();
   }
 
   componentDidUpdate () {


### PR DESCRIPTION
The window.clear function was getting an error in the latest Chrome.

```
Google Chrome 91.0.4472.114 (Official Build) （x86_64）
```

### Reproduction

When I ran the code for `Other examples` at https://diegomura.github.io/react-log/, it crashed with the following error.

![React-log_と_React-log](https://user-images.githubusercontent.com/35218186/124562854-78dc1e00-de7a-11eb-9009-fdcdf8ae0981.png)
